### PR TITLE
Merge dates was not comparing date nodes(?) to date nodes(?).

### DIFF
--- a/lib/csl/locale.rb
+++ b/lib/csl/locale.rb
@@ -484,7 +484,7 @@ module CSL
       return self unless other.has_dates?
 
       if has_dates?
-        other.each_date do |date|
+        other.dates do |date|
           delete_children each_date.select { |d| d[:form] == date[:form] }
           add_child date.deep_copy
         end


### PR DESCRIPTION
This pull request fixes a bad comparison when dates are present (#4), no coverage exists for this test AFAIKT.

Sorry, no unit test, but I'm pretty sure this is OK. 

I can outline what needs to be done though with the test- add two date nodes to one Locale, and one to another, then test that merge! merges the locales successfully.  If you can point me to an example of how to add dates to a Locale I can add a test.