### PR TITLE
Fix deprecation warning on Ruby 2.7 + update CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
-sudo: false
-matrix:
+os: linux
+jobs:
   include:
-  - rvm: 2.5
+  - rvm: 2.7
     env: WITH_COVERALLS=true
+  - rvm: 2.6
+    env: WITH_COVERALLS=false
+  - rvm: 2.5
+    env: WITH_COVERALLS=false
   - rvm: 2.4
     env: WITH_COVERALLS=false
   - rvm: 2.3

--- a/lib/csl/locale.rb
+++ b/lib/csl/locale.rb
@@ -330,9 +330,9 @@ module CSL
     #
     # Calls block once for each term defined by the locale. If no block is
     # given, an enumerator is returned instead.
-    def each_term
+    def each_term(&block)
       if block_given?
-        terms.each(&Proc.new)
+        terms.each(&block)
         self
       else
         enum_for :each_term
@@ -345,12 +345,12 @@ module CSL
     #
     # Calls block once for each date format defined by the locale. If no
     # block is given, an enumerator is returned instead.
-    def each_date
+    def each_date(&block)
       if block_given?
         if date.is_a? CSL::Node
           yield date
         else
-          date.each(&Proc.new)
+          date.each(&block)
         end
       else
         enum_for :each_date

--- a/lib/csl/node.rb
+++ b/lib/csl/node.rb
@@ -268,9 +268,9 @@ module CSL
     alias has_defaults? has_default_attributes?
 
     # Iterates through the Node's attributes
-    def each
+    def each(&block)
       if block_given?
-        attributes.each_pair(&Proc.new)
+        attributes.each_pair(&block)
         self
       else
         to_enum

--- a/lib/csl/treelike.rb
+++ b/lib/csl/treelike.rb
@@ -17,9 +17,9 @@ module CSL
       @nodename ||= self.class.name.split(/::/)[-1].gsub(/([[:lower:]])([[:upper:]])/, '\1-\2').downcase
     end
 
-    def each_child
+    def each_child(&block)
       if block_given?
-        children.each(&Proc.new)
+        children.each(&block)
         self
       else
         enum_for :each_child
@@ -167,11 +167,11 @@ module CSL
     end
 
     # Traverses the node's sub-tree in depth-first order.
-    def each_descendant
+    def each_descendant(&block)
       if block_given?
         each_child do |child|
           yield child
-          child.each_descendant(&Proc.new)
+          child.each_descendant(&block)
         end
 
         self
@@ -376,9 +376,9 @@ module CSL
 
           # Iterates through all children. Nil values are skipped and Arrays
           # expanded.
-          def each
+          def each(&block)
             if block_given?
-              order.each(&Proc.new)
+              order.each(&block)
               self
             else
               to_enum


### PR DESCRIPTION
This pull request removes "warning: Capturing the given block using Proc.new is deprecated; use `&block` instead" message when using Ruby 2.7 by applying the suggested patching.

Also CI config was updated to include Ruby 2.7 and remove this validations messages:
![image](https://user-images.githubusercontent.com/4991925/71482549-e7e6aa00-27e1-11ea-8d49-25eb5369b007.png)

Version bump was **NOT** done. Please remember to do it when releasing the gem.