### PR TITLE
Fix warning that @root is not initialized

### DIFF
--- a/lib/csl/treelike.rb
+++ b/lib/csl/treelike.rb
@@ -230,7 +230,11 @@ module CSL
     %w{ ancestors descendants siblings root depth }.each do |name|
       ivar = "@#{name}"
       define_method("#{name}!") do
-        instance_variable_get(ivar) || send(name)
+        if instance_variable_defined?(ivar)
+          instance_variable_get(ivar) 
+        else 
+          send(name)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes the warning:
.rvm/gems/ruby-2.7.1/gems/csl-1.5.1/lib/csl/treelike.rb:233:
warning: instance variable @root not initialized
by checking if the instance variable is declared before getting its
value.