### PR TITLE
Add prefix/suffix to Group

### DIFF
--- a/lib/csl/style/group.rb
+++ b/lib/csl/style/group.rb
@@ -12,7 +12,7 @@ module CSL
     # the Group calls a variable (either directly or via a macro), and
     # b) all variables that are called are empty.
     class Group < Node
-      attr_struct(*Schema.attr(:formatting, :delimiter, :prefix, :suffix))
+      attr_struct(*Schema.attr(:formatting, :delimiter))
       
       def delimiter
         attributes.fetch(:delimiter, '')

--- a/lib/csl/style/group.rb
+++ b/lib/csl/style/group.rb
@@ -12,10 +12,18 @@ module CSL
     # the Group calls a variable (either directly or via a macro), and
     # b) all variables that are called are empty.
     class Group < Node
-      attr_struct(*Schema.attr(:formatting, :delimiter))
+      attr_struct(*Schema.attr(:formatting, :delimiter, :prefix, :suffix))
       
       def delimiter
         attributes.fetch(:delimiter, '')
+      end
+
+      def prefix
+        attributes.fetch(:prefix, '')
+      end
+
+      def suffix
+        attributes.fetch(:suffix, '')
       end
     end
     


### PR DESCRIPTION
Because I'd like to support ieee csl style someday:

ieee.csl

```
  <!-- Citation -->
  <citation collapse="citation-number">
    <sort>
      <key variable="citation-number"/>
    </sort>
    <layout delimiter=", ">
      <group prefix="[" suffix="]" delimiter=", ">
        <text variable="citation-number"/>
        <text macro="citation-locator"/>
      </group>
    </layout>
  </citation>
```